### PR TITLE
Respawn and camera warning fix

### DIFF
--- a/Meld/Assets/Scripts/current-scripts/Respawn.cs
+++ b/Meld/Assets/Scripts/current-scripts/Respawn.cs
@@ -45,7 +45,7 @@ public class Respawn : MonoBehaviour
             {
                 respawn();
             }
-        } else if (p2Behaviour.GetIsGrounded())
+        } if (p2Behaviour.GetIsGrounded())
         {
             playerGroundedHit = p2Behaviour.GetGroundedHit();
             if (playerGroundedHit.transform.CompareTag("DeathZone"))

--- a/Meld/Assets/Scripts/current-scripts/playerModelController.cs
+++ b/Meld/Assets/Scripts/current-scripts/playerModelController.cs
@@ -5,13 +5,13 @@ using UnityEngine;
 public class playerModelController : MonoBehaviour
 {
 
-    public GameObject camera;
+    public Camera camera;
     public Quaternion startingRotation;
 
     // Start is called before the first frame update
     void Start()
     {
-        camera = GameObject.FindWithTag("MainCamera");
+        camera = GameObject.FindWithTag("MainCamera").GetComponent<Camera>();
         startingRotation = transform.rotation;
     }
 


### PR DESCRIPTION
Fixes:
- Respawn wasn't affecting player 2 due to the "else if" instead of if statement

- Unity UI was giving a warning about the camera not being a GameObject, changed it to specifically refer to a Camera object

